### PR TITLE
FLOW-2151 fixing problem with no UTC times in SAML Service

### DIFF
--- a/src/main/java/com/manywho/services/saml/services/JwtService.java
+++ b/src/main/java/com/manywho/services/saml/services/JwtService.java
@@ -23,8 +23,8 @@ public class JwtService {
     }
 
     public String sign(String identifier, String primaryGroupId, String primaryGroupName, LocalDateTime notBefore, LocalDateTime notAfter) {
-        long notAfterSeconds = LocalDateTime.now().plusMinutes(14).toEpochSecond(ZoneOffset.UTC);
-        long notBeforeSeconds = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC);
+        long notAfterSeconds = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(14).toEpochSecond(ZoneOffset.UTC);
+        long notBeforeSeconds = LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC);
 
         if (notBefore != null) {
             notBeforeSeconds = notBefore.atOffset(ZoneOffset.UTC).toEpochSecond();
@@ -37,7 +37,7 @@ public class JwtService {
         JWTCreator.Builder jwtBuilder = JWT.create()
                 .withIssuer("saml-service")
                 .withClaim("sub", identifier)
-                .withClaim("iat", LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
+                .withClaim("iat", LocalDateTime.now(ZoneOffset.UTC).toEpochSecond(ZoneOffset.UTC))
                 .withClaim("exp", notAfterSeconds)
                 .withClaim("nbf", notBeforeSeconds);
 

--- a/src/test/java/com/manywho/services/saml/SamlServiceTest.java
+++ b/src/test/java/com/manywho/services/saml/SamlServiceTest.java
@@ -10,7 +10,8 @@ public class SamlServiceTest {
     @Test
     public void testSignVerify() {
         JwtService service = new JwtService("test-secret");
-        String token = service.sign("123456", null, null, LocalDateTime.now().minusSeconds(10), LocalDateTime.now().plusSeconds(10));
+        String token = service.sign("123456", null, null,
+                LocalDateTime.now((ZoneOffset.UTC)).minusSeconds(10), LocalDateTime.now().plusSeconds(10));
 
         Assert.assertTrue(service.isValid(token));
     }
@@ -18,7 +19,8 @@ public class SamlServiceTest {
     @Test
     public void testSignVerifyExpiredToken() {
         JwtService service = new JwtService("test-secret");
-        String token = service.sign("123456", null, null, LocalDateTime.now().minusSeconds(20), LocalDateTime.now(ZoneOffset.UTC).minusSeconds(10));
+        String token = service.sign("123456", null, null,
+                LocalDateTime.now((ZoneOffset.UTC)).minusSeconds(20), LocalDateTime.now(ZoneOffset.UTC).minusSeconds(10));
 
         Assert.assertFalse(service.isValid(token));
     }
@@ -27,7 +29,8 @@ public class SamlServiceTest {
     public void testSignVerifyTokenInFuture() {
         JwtService service = new JwtService("test-secret");
         // the not before date is set in the future so the verification fails
-        String token = service.sign("123456", null, null, LocalDateTime.now().plusSeconds(10), LocalDateTime.now(ZoneOffset.UTC).plusSeconds(20));
+        String token = service.sign("123456", null, null,
+                LocalDateTime.now((ZoneOffset.UTC)).plusSeconds(10), LocalDateTime.now(ZoneOffset.UTC).plusSeconds(20));
 
         Assert.assertFalse(service.isValid(token));
     }
@@ -35,7 +38,9 @@ public class SamlServiceTest {
     @Test
     public void testPrimaryGroupInToken() {
         JwtService service = new JwtService("test-secret");
-        String token = service.sign("123456", "group test id 1", "group test name 1", LocalDateTime.now().minusSeconds(10), LocalDateTime.now().plusSeconds(10));
+        String token = service.sign("123456", "group test id 1", "group test name 1",
+                LocalDateTime.now((ZoneOffset.UTC)).minusSeconds(10),
+                LocalDateTime.now((ZoneOffset.UTC)).plusSeconds(10));
 
         Assert.assertTrue(service.isValid(token));
 


### PR DESCRIPTION
Always using UTC to work with dates in SAML Service.
Fixing problems when running test in local, or when the service is hosted in a server that doesn't run on UTC.